### PR TITLE
Remove callback from speech model

### DIFF
--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -4,10 +4,10 @@ class Speech < ApplicationRecord
   has_one_attached :audio, dependent: :destroy
 
   # callback
-  before_validation :create_training
+  # before_validation :create_training
 
-  def create_training
-    training = Training.create(user: user)
-    self.training = training
-  end
+  # def create_training
+  #   training = Training.create(user: user)
+  #   self.training = training
+  # end
 end

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -2,4 +2,5 @@ class Training < ApplicationRecord
   belongs_to :user
   validates :user, presence: true
   has_many :speeches
+  
 end


### PR DESCRIPTION
Definitely going to refactor this. When a speech is made, if a Training doesn't exist, one is created. Then if a user is a teacher, from the Show page they can click a "Correction" button to set a correction value to true. While correction is true, a speech made in the recording studio by that teacher will be added to that Training. The recording studio will have to indicate that the teacher is in Correction mode and which speech they are correcting.